### PR TITLE
Please unregister jquery.dirtyforms from Bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,4 +341,3 @@ Contributors
 
 [Samuel (hleumas)](https://github.com/hleumas)
 
-


### PR DESCRIPTION
Hello,

I realize you must have gotten tired of us to release an official package on Bower and decided to take it upon yourself, and we applaud you for that.

However, we are now working on [formalizing the release process](https://github.com/snikch/jquery.dirtyforms/issues/72) and would like to use the official distribution repo (registered by us) to distribute Bower packages under the same name (`jquery.dirtyforms`).

I have already [contacted Bower about changing the URL](https://github.com/bower/registry/issues/134), but they don't seem to be cooperating.

Please unregister the package from this repo by following the [unregister package](http://bower.io/docs/creating-packages/#unregister) instructions in the Bower documentation (copied below for your convenience) so we can move forward on this. We have already [re-released your 1.0.0 version](https://github.com/NightOwl888/jquery.dirtyforms.dist) so when we make the switch this change will be seamless (except now there will be a minified file with a sourcemap and all of the helpers as separate packages). But please do this ASAP, as we have bug fixes that need to be released as well.
# Unregister with Bower

> You can unregister packages with [bower `unregister`](http://bower.io/docs/api/#unregister). You first need to authenticate with GitHub with [`bower login`](http://bower.io/docs/api/#login) to confirm you are a contributor to the package repo.

```
bower login
# enter username and password
? Username:
? Password:
# unregister packages after successful login
bower unregister <package>
```

> You’ll likely want to [`bower cache clean`](http://bower.io/docs/api#cache-clean) after your change. If the above doesn’t work for you, you can [request a package be unregistered manually](https://github.com/bower/bower/issues/120).
